### PR TITLE
nethserver-collectd.include: fix syntax for Duplicity 0.7

### DIFF
--- a/root/etc/backup-data.d/nethserver-collectd.include
+++ b/root/etc/backup-data.d/nethserver-collectd.include
@@ -1,1 +1,1 @@
-/var/lib/collectd/
+/var/lib/collectd


### PR DESCRIPTION
NethServer/dev#5101
