### PR TITLE
Ignore IFB devices

### DIFF
--- a/root/etc/collectd.d/00plugins.conf
+++ b/root/etc/collectd.d/00plugins.conf
@@ -28,6 +28,7 @@ LoadPlugin "swap"
 LoadPlugin "interface"
 <Plugin "interface">
         Interface "lo"
+        Interface "/.*-ifb$/"
         IgnoreSelected true
 </Plugin>
 


### PR DESCRIPTION
IFB graphs always show a "mirrored" view of the Receive traffic on the real device.
IFB graphs don't add information but clutter the graph view.
