### PR TITLE
cron.daily: don't fail if dir names have spaces

### DIFF
--- a/root/etc/cron.daily/collectd_cleanup
+++ b/root/etc/cron.daily/collectd_cleanup
@@ -1,3 +1,3 @@
 # Remove old and unused rrd databases
 find /var/lib/collectd/ -type f -mtime +0 -delete
-find /var/lib/collectd/ -type d -empty | xargs -I SUB -r rmdir "SUB"
+find /var/lib/collectd/ -type d -empty -print0 | xargs -0 -r rmdir

--- a/root/etc/cron.daily/collectd_cleanup
+++ b/root/etc/cron.daily/collectd_cleanup
@@ -1,3 +1,3 @@
 # Remove old and unused rrd databases
 find /var/lib/collectd/ -type f -mtime +0 -delete
-find /var/lib/collectd/ -type d -empty | xargs -r rmdir
+find /var/lib/collectd/ -type d -empty | xargs -I SUB -r rmdir "SUB"


### PR DESCRIPTION
don't fail if a collectd plugin creates graphs with space in name.