### PR TITLE
Exclude all tmpfs

### DIFF
--- a/root/etc/collectd.d/df.conf
+++ b/root/etc/collectd.d/df.conf
@@ -1,8 +1,5 @@
 <Plugin "df">
   MountPoint "/dev"
-  MountPoint "/dev/shm"
-  MountPoint "/run"
-  MountPoint "/run/user/0"
-  MountPoint "/sys/fs/cgroup"
+  FSType tmpfs
   IgnoreSelected true
 </Plugin>


### PR DESCRIPTION
This change correctly excludes all /run entries